### PR TITLE
Open CV and Politics of AI nav links in same tab instead of new tab

### DIFF
--- a/01_CV.markdown
+++ b/01_CV.markdown
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: CV
+menu: main
 permalink: /cv/
 ---
 

--- a/03_AI.markdown
+++ b/03_AI.markdown
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: 'Politics of AI'
+menu: main
 permalink: /ai/
 ---
 

--- a/_config.yml
+++ b/_config.yml
@@ -32,12 +32,6 @@ author_display: true
 googlescholar_link: https://scholar.google.com/citations?user=VT1o_zkAAAAJ&hl=de
 uni_link: https://www.alexandria.unisg.ch/entities/person/Matthias_Haslberger/otherInfo
 
-nav_ext_links:
-  - name: CV
-    url: https://matthiashaslberger.github.io/cv/
-  - name: Politics of AI
-    url: https://matthiashaslberger.github.io/ai/
-
 # Build settings
 # theme: academic
 remote_theme: gaalcaras/academic


### PR DESCRIPTION
Move CV and Politics of AI pages from nav_ext_links (which renders with target="_blank") to regular menu pages (menu: main), matching how the Research page is already configured. PDF links on those pages retain target="_blank" so documents still open in a new tab.

https://claude.ai/code/session_018bBgArvJsM1FUk8CuvNfyp